### PR TITLE
Add support for TravisCI and Contribution Guidelines initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - 8
+  - 10
+cache:
+  yarn: true
+  directories: node_modules
+install:
+  - yarn
+script:
+  - yarn test:unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+## Contribute
+<!-- Add documentation about to contribute in project -->


### PR DESCRIPTION
## Issue
Add support for TravisCI and Contribution Guidelines initialization

## Solution
- Added `.travis.yml` configuration.
- Added `CONTRIBUTING.md` documentation.

## Testing
Not yet

#1 